### PR TITLE
Update compose.material

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // (in a separate module for demo project and in testMain).
     // With compose.desktop.common you will also lose @Preview functionality
     implementation(compose.desktop.currentOs)
-    implementation("org.jetbrains.compose.material3:material3-desktop:1.6.2")
+    implementation("org.jetbrains.compose.material3:material3-desktop:1.6.10")
     implementation("org.jetbrains.compose.material:material-icons-extended:1.6.10")
     implementation("androidx.room:room-runtime:$roomVersion")
 //    implementation("androidx.room:room-ktx:$roomVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     // With compose.desktop.common you will also lose @Preview functionality
     implementation(compose.desktop.currentOs)
     implementation("org.jetbrains.compose.material3:material3-desktop:1.6.2")
-    implementation("org.jetbrains.compose.material:material-icons-extended:1.6.10-dev1613")
+    implementation("org.jetbrains.compose.material:material-icons-extended:1.6.10")
     implementation("androidx.room:room-runtime:$roomVersion")
 //    implementation("androidx.room:room-ktx:$roomVersion")
     ksp("androidx.room:room-compiler:$roomVersion")


### PR DESCRIPTION
Bump org.jetbrains.compose.material:material-icons-extended from 1.6.10-dev1613 to 1.6.10 (9571d17fa127a6ad6023c290d02b0d1d256fddd1)


Bump org.jetbrains.compose.material3:material3-desktop from 1.6.2 to 1.6.10(335587bfa58f1065eea05a5a54d2c849ab7d3e84)